### PR TITLE
Function `cdecl` Attribute

### DIFF
--- a/Compiler/modules/SyntaxTree.cpp
+++ b/Compiler/modules/SyntaxTree.cpp
@@ -1578,28 +1578,38 @@ namespace sclc {
                     nextAttributes.clear();
                 }
             } else {
-                if (tokens[i].getType() == tok_identifier || tokens[i].getType() == tok_default) {
-                    if (tokens[i].getValue() == "typealias") {
-                        i++;
-                        std::string type = tokens[i].getValue();
-                        i++;
-                        if (tokens[i].getType() != tok_string_literal) {
-                            FPResult result;
-                            result.message = "Expected string, but got '" + tokens[i].getValue() + "'";
-                            result.value = tokens[i].getValue();
-                            result.line = tokens[i].getLine();
-                            result.in = tokens[i].getFile();
-                            result.type = tokens[i].getType();
-                            result.column = tokens[i].getColumn();
-                            result.column = tokens[i].getColumn();
-                            result.success = false;
-                            errors.push_back(result);
-                            continue;
-                        }
-                        std::string replacement = tokens[i].getValue();
-                        typealiases[type] = replacement;
+
+                auto validAttribute = [](Token& t) -> bool {
+                    return t.getValue() == "expect" ||
+                           t.getValue() == "export" ||
+                           t.getValue() == "no_cleanup" ||
+                           t.getValue() == "cdecl" ||
+                           t.getValue() == "default" ||
+                           t.getValue() == "static" ||
+                           t.getValue() == "private" ||
+                           t.getType()  == tok_string_literal;
+                };
+
+                if (tokens[i].getValue() == "typealias") {
+                    i++;
+                    std::string type = tokens[i].getValue();
+                    i++;
+                    if (tokens[i].getType() != tok_string_literal) {
+                        FPResult result;
+                        result.message = "Expected string, but got '" + tokens[i].getValue() + "'";
+                        result.value = tokens[i].getValue();
+                        result.line = tokens[i].getLine();
+                        result.in = tokens[i].getFile();
+                        result.type = tokens[i].getType();
+                        result.column = tokens[i].getColumn();
+                        result.column = tokens[i].getColumn();
+                        result.success = false;
+                        errors.push_back(result);
                         continue;
                     }
+                    std::string replacement = tokens[i].getValue();
+                    typealiases[type] = replacement;
+                } else if (validAttribute(tokens[i])) {
                     nextAttributes.push_back(tokens[i].getValue());
                 }
             }

--- a/Scale/Frameworks/Scale.framework/include/Scale/core.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/core.scale
@@ -3,88 +3,75 @@ import Scale.io
 import Scale.types
 import Scale.util.array
 
-function sleep(_millis_: int): none
-  inline_c
-    sleep(*_millis_);
-  end_inline
-end
+expect function memset(ptr: [any], val: int, len: int): [any]
+expect function memcpy(dst: [any], src: [any], n: int): [any]
+cdecl "ctrl_stack_size"
+expect function sizeofStack(): int
+cdecl "_scl_sleep"
+expect function sleep(_millis_: int): none
+
+cdecl "system"
+expect function __c_system(cmd: [int8]): int
+cdecl "getenv"
+expect function __c_getenv(cmd: [int8]): [int8]?
+cdecl "strdup"
+expect function __c_strdup(s: [int8]): [int8]
+cdecl "strtok"
+expect function __c_strtok(s: any, delim: [int8]): [int8]?
+cdecl "atoll"
+expect function __c_atoll(s: [int8]): int
+cdecl "atof"
+expect function __c_atof(s: [int8]): float
+
+expect function _scl_alloc(_sz_: int): [any]?
+expect function _scl_realloc(_ptr_: [any], _sz_: int): [any]?
+expect function _scl_free(_ptr_: [any]): none
 
 function system(_cmd_: str): int
-  decl ret: int
-  inline_c
-    *ret = system((*_cmd_)->_data);
-  end_inline
-  ret return
+  _cmd_:view __c_system return
 end
 
 function getenv(_key_: str): str?
-  decl ptr: mut [int8]
-  inline_c
-    *ptr = getenv((*_key_)->_data);
-  end_inline
-  ptr str::new return
+  _key_:view __c_getenv => decl ptr
+  if ptr then
+    ptr!! str::new return
+  fi
+  nil return
 end
 
-function sizeofStack(): int
-  inline_c
-    _scl_push()->i = _scl_internal_stack.ptr;
-  end_inline
-  return
-end
-
-function malloc(_size_: int): [any]?
-  decl s: [any]
-  inline_c
-    *s = _scl_alloc(*_size_);
-    if (!(*s)) {
+function malloc(_size_: int) s: [any]?
+  _size_ _scl_alloc => s
+  if s ! then
+    inline_c
       _scl_security_throw(EX_BAD_PTR, "malloc() failed!");
-      *s = NULL;
-    }
-  end_inline
-  s return
+    end_inline
+  fi
+  return
 end
 
 function realloc(_size_: int, _ptr_: [any]): [any]?
-  inline_c
-    *_ptr_ = _scl_realloc(*_ptr_, *_size_);
-    if (!(*_ptr_)) {
+  _ptr_ _size_ _scl_realloc => _ptr_
+  if _ptr_ ! then
+    inline_c
       _scl_security_throw(EX_BAD_PTR, "realloc() failed!");
-      *_ptr_ = NULL;
-    }
-  end_inline
+    end_inline
+  fi
   _ptr_ return
 end
 
-function memset(ptr: [any], val: int, len: int): [any]
-  inline_c
-    _scl_push()->v = memset(*ptr, *val, *len);
-  end_inline
-  return
-end
-
-function memcpy(dst: [any], src: [any], n: int): [any]
-  inline_c
-    _scl_push()->v = memcpy(*dst, *src, *n);
-  end_inline
-  return
-end
-
 function free(_ptr_: [any]): none
-  inline_c
-    _scl_free(*_ptr_);
-  end_inline
+  _ptr_ _scl_free
 end
 
 function strsplit(_str_: str, _delim_: str): Array
   10 Array::new => decl arr: Array
-  inline_c
-    scl_int8* string = strdup((*_str_)->_data);
-    scl_int8* line = strtok(string, (*_delim_)->_data);
-    while (line != NULL) {
-      Method_Array$push(_scl_create_string(line), *arr);
-      line = strtok(NULL, (*_delim_)->_data);
-    }
-  end_inline
+  _str_:view => decl string
+  string _delim_:view __c_strtok => decl line
+
+  while line do
+    line!! str::new arr:push
+    nil _delim_:view __c_strtok => line
+  done
   arr return
 end
 
@@ -99,32 +86,24 @@ function time(): float
 end
 
 function longToString(_long_: int): str
-  decl out: [int8]
+  25 malloc => decl out: [int8]
   inline_c
-    *out = _scl_alloc(25);
 	  sprintf(*out, SCL_INT_FMT, *_long_);
   end_inline
   out str::new return
 end
 
 function stringToLong(_str_: str): int
-  inline_c
-    _scl_push()->i = atoll((*_str_)->_data);
-  end_inline
-  return
+  _str_:view __c_atoll return
 end
 
 function stringToDouble(_str_: str): float
-  inline_c
-    _scl_push()->f = atof((*_str_)->_data);
-  end_inline
-  return
+  _str_:view __c_atof return
 end
 
 function doubleToString(_double_: float): str
-  decl out: [int8]
+  100 malloc => decl out: [int8]
   inline_c
-    *out = _scl_alloc(100);
 	  sprintf(*out, "%f", *_double_);
   end_inline
   out str::new return

--- a/Scale/Frameworks/Scale.framework/include/Scale/debug.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/debug.scale
@@ -1,5 +1,15 @@
 import Scale.fmt
 
+cdecl "print_stacktrace"
+expect function trace(): none
+
+cdecl "_scl_security_safe_exit"
+expect function __c_exit(i: int): none
+cdecl "_scl_catch_final"
+expect function __c_scl_catch_final(_sig_: int): none
+cdecl "raise"
+expect function __c_raise(_sig_: int): int
+
 function dumpStack(): none
   inline_c
     printf("Dump:\n");
@@ -11,36 +21,27 @@ function dumpStack(): none
   end_inline
 end
 
-function trace(): none
-  inline_c
-    print_stacktrace();
-  end_inline
-end
-
 function crash(): none
-  inline_c
-    _scl_security_safe_exit(1);
-  end_inline
+  1 __c_exit
 end
 
 function raise(_sig_: int): none
-  inline_c
-    if (*_sig_ != 2 && *_sig_ != 4 && *_sig_ != 6 && *_sig_ != 8 && *_sig_ != 11) {
-      int raised = raise(*_sig_);
-      if (raised != 0) {
-        _scl_catch_final(*_sig_);
-      }
-    } else {
-      _scl_catch_final(*_sig_);
-    }
-  end_inline
+  if _sig_ 2 != _sig_ 4 != && _sig_ 6 != _sig_ 8 != && && _sig_ 11 != && then
+    _sig_ __c_raise => decl raised
+    if raised ! then
+      _sig_ __c_scl_catch_final
+    fi
+  else
+    _sig_ __c_scl_catch_final
+  fi
 end
 
+cdecl "getchar"
+expect function __c_getchar(): int8
+
 function breakPoint(): none
-  inline_c
-    printf("Hit breakPoint. Press enter to continue.\n");
-	  getchar();
-  end_inline
+  "Hit breakPoint. Press enter to continue." puts
+  __c_getchar
 end
 
 sealed struct Exception

--- a/Scale/Frameworks/Scale.framework/include/Scale/file.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/file.scale
@@ -1,49 +1,27 @@
 typealias file "FILE*"
 
+cdecl "fopen"
+expect function __c_fopen(_name_: [int8], _mode_: [int8]): file?
+cdecl "fwrite"
+expect function __c_fwrite(_buf_: any, _size_: int, _num_elem_: int, _file_: file): none
+cdecl "fread"
+expect function __c_fread(_buf_: any, _num_elem_: int, _size_: int, _f_: file): none
+
+expect function fclose(_file_: file): none
+expect function ftell(_file_: file): int
+expect function fileno(_file_: file): int
+expect function fseek(_file_: file, _offset_: int, _whence_: int): none
+
 function fopen(_filename_: str, _mode_: str): file?
-  decl _f_: file?
-  inline_c
-    *_f_ = fopen((*_filename_)->_data, (*_mode_)->_data);
-  end_inline
-  _f_ return
-end
-
-function fclose(_file_: file): none
-  inline_c
-    fclose(*_file_);
-  end_inline
-end
-
-function ftell(_file_: file): int
-  inline_c
-    _scl_push()->i = ftell(*_file_);
-  end_inline
-  return
-end
-
-function fileno(_file_: file): int
-  inline_c
-    _scl_push()->i = fileno(*_file_);
-  end_inline
-  return
-end
-
-function fseek(_file_: file, _whence_: int, _offset_: int): none
-  inline_c
-    fseek(*_file_, *_offset_, *_whence_);
-  end_inline
+  _filename_:view _mode_:view __c_fopen return
 end
 
 function fwrite(_buf_: any, _size_: int, _file_: file): none
-  inline_c
-    int _ignored = fwrite(*_buf_, 1, *_size_, *_file_); (void) _ignored;
-  end_inline
+  _buf_ 1 _size_ _file_ __c_fwrite
 end
 
 function fwrites(_buf_: str, _size_: int, _file_: file): none
-  inline_c
-    int _ignored = fwrite((*_buf_)->_data, 1, *_size_, *_file_); (void) _ignored;
-  end_inline
+  _buf_:view 1 _size_ _file_ __c_fwrite
 end
 
 function fputs(_file_: file, _str_: str): none
@@ -60,21 +38,19 @@ function fputfloat(_file_: file, _float_: float): none
 end
 
 function fread(_f_: file, _size_: int): [any]?
-  decl _buf_: [any]? _size_ malloc => _buf_
-  inline_c
-    int _ignored = fread(*_buf_, 1, *_size_, *_f_); (void) _ignored;
-  end_inline
+  _size_ malloc => decl _buf_: [any]?
+  _buf_ 1 _size_ _f_ fread
   _buf_ return
 end
 
 function fseekstart(_f_: file, _offset_: int): none
-  _f_ 0 _offset_ fseek
+  _f_ _offset_ 0 fseek
 end
 
 function fseekend(_f_: file, _offset_: int): none
-  _f_ 2 _offset_ fseek
+  _f_ _offset_ 2 fseek
 end
 
 function fseekcur(_f_: file, _offset_: int): none
-  _f_ 1 _offset_ fseek
+  _f_ _offset_ 1 fseek
 end

--- a/Scale/Frameworks/Scale.framework/include/Scale/io.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/io.scale
@@ -1,38 +1,39 @@
+cdecl "write"
+expect function __c_write(_fd_: int, _str_: [int8], _len_: int): none
+cdecl "read"
+expect function __c_read(_fd_: int, _buf_: [int8], _n_: int): none
+cdecl "puts"
+expect function __c_puts(_str_: [int8]): none
+
 function write(_fd_: int, _str_: str): none
-  inline_c
-  int _ignored = write(*_fd_, (*_str_)->_data, (*_str_)->_len); (void) _ignored;
-  end_inline
+  _fd_ _str_:view _str_:size __c_write
 end
 
 function read(_fd_: int, _n_: int): str?
   _n_ malloc => decl buf: [int8]
-  inline_c
-    int _ignored = read(*_fd_, *buf, *_n_); (void) _ignored;
-  end_inline
+  _fd_ buf _n_ __c_read
   buf str::new return
 end
 
 function puts(_str_: str): none
-  inline_c
-  puts((*_str_)->_data);
-  end_inline
+  _str_:view __c_puts
 end
 
 function eputs(_str_: str): none
   inline_c
-  fprintf(stderr, "%s\n", (*_str_)->_data);
+    fprintf(stderr, "%s\n", (*_str_)->_data);
   end_inline
 end
 
 function putint(_int_: int): none
   inline_c
-  printf(SCL_INT_FMT "\n", *_int_);
+    printf(SCL_INT_FMT "\n", *_int_);
   end_inline
 end
 
 function putfloat(_f_: float): none
   inline_c
-  printf("%f\n", *_f_);
+    printf("%f\n", *_f_);
   end_inline
 end
 

--- a/Scale/Frameworks/Scale.framework/include/Scale/math.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/math.scale
@@ -12,141 +12,23 @@ function __init__math_scale(): none
   end_inline
 end
 
-function sqrt(_f_: float): float
-  decl r: float
-  inline_c
-    *r = sqrt(*_f_);
-  end_inline
-  r return
-end
-
-function sin(_f_: float): float
-  decl r: float
-  inline_c
-    *r = sin(*_f_);
-  end_inline
-  r return
-end
-
-function cos(_f_: float): float
-  decl r: float
-  inline_c
-    *r = cos(*_f_);
-  end_inline
-  r return
-end
-
-function tan(_f_: float): float
-  decl r: float
-  inline_c
-    *r = tan(*_f_);
-  end_inline
-  r return
-end
-
-function asin(_f_: float): float
-  decl r: float
-  inline_c
-    *r = asin(*_f_);
-  end_inline
-  r return
-end
-
-function acos(_f_: float): float
-  decl r: float
-  inline_c
-    *r = acos(*_f_);
-  end_inline
-  r return
-end
-
-function atan(_f_: float): float
-  decl r: float
-  inline_c
-    *r = atan(*_f_);
-  end_inline
-  r return
-end
-
-function atan2(_f1_: float, _f2_: float): float
-  decl r: float
-  inline_c
-    *r = atan2(*_f1_, *_f2_);
-  end_inline
-  r return
-end
-
-function sinh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = sinh(*_f_);
-  end_inline
-  r return
-end
-
-function cosh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = cosh(*_f_);
-  end_inline
-  r return
-end
-
-function tanh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = tanh(*_f_);
-  end_inline
-  r return
-end
-
-function asinh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = asinh(*_f_);
-  end_inline
-  r return
-end
-
-function acosh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = acosh(*_f_);
-  end_inline
-  r return
-end
-
-function atanh(_f_: float): float
-  decl r: float
-  inline_c
-    *r = atanh(*_f_);
-  end_inline
-  r return
-end
-
-function exp(_f_: float): float
-  decl r: float
-  inline_c
-    *r = exp(*_f_);
-  end_inline
-  r return
-end
-
-function log(_f_: float): float
-  decl r: float
-  inline_c
-    *r = log(*_f_);
-  end_inline
-  r return
-end
-
-function log10(_f_: float): float
-  decl r: float
-  inline_c
-    *r = log10(*_f_);
-  end_inline
-  r return
-end
+expect function sqrt(_f_: float): float
+expect function sin(_f_: float): float
+expect function cos(_f_: float): float
+expect function tan(_f_: float): float
+expect function asin(_f_: float): float
+expect function acos(_f_: float): float
+expect function atan(_f_: float): float
+expect function atan2(_f1_: float, _f2_: float): float
+expect function sinh(_f_: float): float
+expect function cosh(_f_: float): float
+expect function tanh(_f_: float): float
+expect function asinh(_f_: float): float
+expect function acosh(_f_: float): float
+expect function atanh(_f_: float): float
+expect function exp(_f_: float): float
+expect function log(_f_: float): float
+expect function log10(_f_: float): float
 
 function random(): int
   decl r: int

--- a/Scale/Frameworks/Scale.framework/include/Scale/types.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/types.scale
@@ -7,6 +7,17 @@ typealias uint16 "scl_uint16"
 typealias uint8 "scl_uint8"
 typealias lambda "_scl_lambda"
 
+cdecl "strlen"
+expect function __c_strlen(_str_: [int8]) len: int
+cdecl "strcmp"
+expect function __c_strcmp(_str1_: [int8], _str2_: [int8]): int
+cdecl "strdup"
+expect function __c_strdup(_str_: [int8]): [int8]
+cdecl "strncmp"
+expect function __c_strncmp(_str1_: [int8], _str2_: [int8], _n_: int): int
+cdecl "strcpy"
+expect function __c_strcpy(dest: [int8], src: [int8]): none
+
 sealed struct str is IEquatable, ICloneable, IStringifyable
   private decl _data: [int8]
   private decl _len: int
@@ -28,7 +39,7 @@ sealed struct str is IEquatable, ICloneable, IStringifyable
   end
 
   function equals(other: str): bool
-    self._data other._data strcmp return
+    self._data other._data __c_strcmp 0 == return
   end
 
   function ==(other: str): bool
@@ -79,69 +90,30 @@ sealed struct str is IEquatable, ICloneable, IStringifyable
   end
 
   function startsWith(_s_: str): bool
-    self._data _s_._data _s_:size strncmp return
+    self._data _s_._data _s_:size __c_strncmp 0 == return
   end
 
   function view(): [int8]
-    self._data strdup return
+    self._data __c_strdup return
   end
 
   function init(data: [int8]): none
     data => self._data
-    inline_c
-      (*self)->_len = strlen(*data);
-    end_inline
-  end
-
-  private function strlen(_str_: [int8]) len: int
-    inline_c
-      *len = strlen(*_str_);
-    end_inline
-    return
-  end
-
-  private function strcmp(_str1_: [int8], _str2_: [int8]): bool
-    decl t: bool
-    inline_c
-      *t = (strcmp(*_str1_, *_str2_) == 0);
-    end_inline
-    t return
-  end
-
-  private function strdup(_str_: [int8]): [int8]
-    decl s: [int8]
-    inline_c
-      *s = strdup(*_str_);
-    end_inline
-    s return
-  end
-
-  private function strncmp(_str1_: [int8], _str2_: [int8], _n_: int): bool
-    decl t: bool
-    inline_c
-      *t = (strncmp(*_str1_, *_str2_, *_n_) == 0);
-    end_inline
-    t return
+    data __c_strlen => self._len
   end
 
   private function concat(_str1_: [int8], _str2_: [int8]): [int8]
     decl out: [int8]
-    _str1_ strlen => decl len: int
-    _str2_ strlen => decl len2: int
+    _str1_ __c_strlen => decl len: int
+    _str2_ __c_strlen => decl len2: int
 
     len len2 + 1 + malloc => out
 
-    out _str1_ strcpy
+    out _str1_ __c_strcpy
     inline_c
       strcat(*out, *_str2_);
     end_inline
 
     out return
-  end
-
-  private function strcpy(dest: [int8], src: [int8]): none
-    inline_c
-      strcpy(*dest, *src);
-    end_inline
   end
 end

--- a/Scale/Frameworks/Scale.framework/include/Scale/util/array.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/util/array.scale
@@ -13,24 +13,23 @@ sealed struct Array is IIterable
   private decl pos: readonly int
   
   function sort(): none
-    inline_c
-      scl_int i = 0;
-      while (i < (scl_int) (*self)->count) {
-        scl_int speicher = (scl_int) Method_Array$get(i, (*self));
-        scl_int j = i - 1;
-        while (j >= 0) {
-          if (speicher < (scl_int) Method_Array$get(j, (*self))) {
-            Method_Array$set(j + 1, Method_Array$get(j, (*self)), (*self));
-            Method_Array$set(j, (scl_any) speicher, (*self));
-          } else {
-            Method_Array$set(j + 1, (scl_any) speicher, (*self));
-            break;
-          }
-          j--;
-        }
-        i++;
-      }
-    end_inline
+    0 => decl i
+
+    while i self.count < do
+      i self:get => decl tmp
+      i 1 - => decl j
+      while j 0 >= do
+        if tmp j self:get < then
+          j 1 + j self:get self:set
+          j tmp self:set
+        else
+          j 1 + tmp self:set
+          break
+        fi
+        j-- => j
+      done
+      i++ => i
+    done
   end
 
   function get(index: int): any?

--- a/loc.txt
+++ b/loc.txt
@@ -19,20 +19,20 @@
      110 Compiler/modules/Function.cpp
      113 Compiler/modules/InfoDumper.cpp
      151 Compiler/modules/Parser.cpp
-    1664 Compiler/modules/SyntaxTree.cpp
+    1674 Compiler/modules/SyntaxTree.cpp
      260 Compiler/modules/TokenHandlers.cpp
      531 Compiler/modules/Tokenizer.cpp
-    4042 Compiler/modules/Transpiler.cpp
-     155 Scale/Frameworks/Scale.framework/include/Scale/core.scale
-      68 Scale/Frameworks/Scale.framework/include/Scale/debug.scale
-      80 Scale/Frameworks/Scale.framework/include/Scale/file.scale
+    4064 Compiler/modules/Transpiler.cpp
+     134 Scale/Frameworks/Scale.framework/include/Scale/core.scale
+      69 Scale/Frameworks/Scale.framework/include/Scale/debug.scale
+      56 Scale/Frameworks/Scale.framework/include/Scale/file.scale
       13 Scale/Frameworks/Scale.framework/include/Scale/fmt.scale
-      43 Scale/Frameworks/Scale.framework/include/Scale/io.scale
-     177 Scale/Frameworks/Scale.framework/include/Scale/math.scale
+      44 Scale/Frameworks/Scale.framework/include/Scale/io.scale
+      59 Scale/Frameworks/Scale.framework/include/Scale/math.scale
       49 Scale/Frameworks/Scale.framework/include/Scale/sclobject.scale
-     147 Scale/Frameworks/Scale.framework/include/Scale/types.scale
+     119 Scale/Frameworks/Scale.framework/include/Scale/types.scale
        5 Scale/Frameworks/Scale.framework/include/Scale/util/arg.scale
-     196 Scale/Frameworks/Scale.framework/include/Scale/util/array.scale
+     195 Scale/Frameworks/Scale.framework/include/Scale/util/array.scale
        4 Scale/Frameworks/Scale.framework/include/Scale/util/arrays.scale
        5 Scale/Frameworks/Scale.framework/include/Scale/util/bounds.scale
        3 Scale/Frameworks/Scale.framework/include/Scale/util/cloneable.scale
@@ -46,7 +46,7 @@
        3 Scale/Frameworks/Scale.framework/include/Scale/util/stringifyable.scale
       35 Scale/Frameworks/Scale.framework/include/Scale/util/thread.scale
       11 Scale/Frameworks/Scale.framework/include/Scale/util/triple.scale
-    1112 Scale/Internal/scale_internal.c
+    1102 Scale/Internal/scale_internal.c
      322 Scale/Internal/scale_internal.h
       11 examples/arguments.scale
       14 examples/array-destructuring.scale
@@ -76,4 +76,4 @@
       11 examples/while.scale
        9 interop-example/foo.c
       14 interop-example/main.scale
-   13643 total
+   13475 total


### PR DESCRIPTION
The `cdecl` function attribute can be used to declare the symbol name of the function in the generated binary.
In conjunction with the `expect` attribute, you can have a different name for the function in Scale to the symbol in the binary.

Example:
```
cdecl "bar"
function foo(): none
    "Foo!" puts
end
```

This will make the function `foo` have the assembly symbol `bar`.

**WARNING:** The symbol might get prefixed with `_` depending on your system, so on, for example macOS, the symbol will actually be `_bar` to keep this feature compatible with C!
