### PR TITLE
`asm` Function Attribute and `c!`

### DIFF
--- a/Compiler/headers/TokenType.hpp
+++ b/Compiler/headers/TokenType.hpp
@@ -28,7 +28,7 @@ namespace sclc
         tok_do,             // do
         tok_done,           // done
         tok_extern,         // extern
-        tok_extern_c,       // extern_c
+        tok_extern_c,       // c!
         tok_break,          // break
         tok_continue,       // continue
         tok_for,            // for

--- a/Compiler/modules/SyntaxTree.cpp
+++ b/Compiler/modules/SyntaxTree.cpp
@@ -1587,6 +1587,7 @@ namespace sclc {
                            t.getValue() == "default" ||
                            t.getValue() == "static" ||
                            t.getValue() == "private" ||
+                           t.getValue() == "asm" ||
                            t.getType()  == tok_string_literal;
                 };
 

--- a/Compiler/modules/Tokenizer.cpp
+++ b/Compiler/modules/Tokenizer.cpp
@@ -259,11 +259,29 @@ namespace sclc
             syntaxWarn("The 'store' keyword is deprecated! Use '=>' instead.");
         }
 
-        if (value == "inline_c") {
+        if (value == "pragma") {
+            if (c == '!') {
+                value += c;
+                c = source[++current];
+                column++;
+            }
+        } else if (value == "c") {
+            if (c == '!') {
+                value += c;
+                c = source[++current];
+                column++;
+            }
+        }
+
+        if (value == "inline_c" || value == "c!") {
+            bool newInline = value == "c!";
+            if (!newInline) {
+                syntaxWarn("The 'inline_c' keyword is deprecated! Use 'c!' instead.");
+            }
             value = "";
             int startLine = line;
             int startColumn = column;
-            while (strncmp("end_inline", (source + current), strlen("end_inline")) != 0) {
+            while (strncmp((newInline ? "end" : "end_inline"), (source + current), strlen((newInline ? "end" : "end_inline"))) != 0) {
                 value += c;
                 c = source[current++];
                 column++;
@@ -272,20 +290,12 @@ namespace sclc
                     column = 0;
                 }
             }
-            current += strlen("end_inline");
+            current += strlen((newInline ? "end" : "end_inline"));
             return Token(tok_extern_c, value, startLine, filename, startColumn);
         }
 
         if (value == "extern") {
             syntaxWarn("'extern' is deprecated! Use 'expect' instead!");
-        }
-
-        if (value == "pragma") {
-            if (c == '!') {
-                value += c;
-                c = source[++current];
-                column++;
-            }
         }
 
         TOKEN("function",   tok_function, line, filename);

--- a/Compiler/modules/Transpiler.cpp
+++ b/Compiler/modules/Transpiler.cpp
@@ -129,13 +129,20 @@ namespace sclc {
     }
 
     std::string generateSymbolForFunction(Function* f) {
+        auto indexOf = [](std::vector<std::string> v, std::string s) -> size_t {
+            for (size_t i = 0; i < v.size(); i++) {
+                if (v.at(i) == s) return i;
+            }
+            return -1;
+        };
+
+        if (contains<std::string>(f->getModifiers(), "asm")) {
+            std::string label = f->getModifiers().at(indexOf(f->getModifiers(), "asm") + 1);
+
+            return std::string("\"") + label + "\"";
+        }
+
         if (contains<std::string>(f->getModifiers(), "cdecl")) {
-            auto indexOf = [](std::vector<std::string> v, std::string s) -> size_t {
-                for (size_t i = 0; i < v.size(); i++) {
-                    if (v.at(i) == s) return i;
-                }
-                return -1;
-            };
             std::string cLabel = f->getModifiers().at(indexOf(f->getModifiers(), "cdecl") + 1);
 
             return "_scl_macro_to_string(__USER_LABEL_PREFIX__) " + std::string("\"") + cLabel + "\"";

--- a/Scale/Frameworks/Scale.framework/include/Scale/core.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/core.scale
@@ -42,9 +42,9 @@ end
 function malloc(_size_: int) s: [any]?
   _size_ _scl_alloc => s
   if s ! then
-    inline_c
+    c!
       _scl_security_throw(EX_BAD_PTR, "malloc() failed!");
-    end_inline
+    end
   fi
   return
 end
@@ -52,9 +52,9 @@ end
 function realloc(_size_: int, _ptr_: [any]): [any]?
   _ptr_ _size_ _scl_realloc => _ptr_
   if _ptr_ ! then
-    inline_c
+    c!
       _scl_security_throw(EX_BAD_PTR, "realloc() failed!");
-    end_inline
+    end
   fi
   _ptr_ return
 end
@@ -77,19 +77,19 @@ end
 
 function time(): float
   decl secs: float
-  inline_c
+  c!
     struct timeval tv;
     gettimeofday(&tv, NULL);
     *secs = (scl_float)(tv.tv_usec) / 1000000 + (scl_float)(tv.tv_sec);
-  end_inline
+  end
   secs return
 end
 
 function longToString(_long_: int): str
   25 malloc => decl out: [int8]
-  inline_c
+  c!
 	  sprintf(*out, SCL_INT_FMT, *_long_);
-  end_inline
+  end
   out str::new return
 end
 
@@ -103,9 +103,9 @@ end
 
 function doubleToString(_double_: float): str
   100 malloc => decl out: [int8]
-  inline_c
+  c!
 	  sprintf(*out, "%f", *_double_);
-  end_inline
+  end
   out str::new return
 end
 

--- a/Scale/Frameworks/Scale.framework/include/Scale/debug.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/debug.scale
@@ -11,14 +11,14 @@ cdecl "raise"
 expect function __c_raise(_sig_: int): int
 
 function dumpStack(): none
-  inline_c
+  c!
     printf("Dump:\n");
     for (ssize_t i = _scl_internal_stack.ptr - 1; i >= 0; i--) {
       scl_int v = _scl_internal_stack.data[i].i;
       printf("   %zd: 0x" SCL_INT_HEX_FMT ", " SCL_INT_FMT "\n", i, v, v);
     }
 	  printf("\n");
-  end_inline
+  end
 end
 
 function crash(): none
@@ -49,7 +49,7 @@ sealed struct Exception
 end
 
 function throw(ex: Exception): none
-  inline_c
+  c!
     _scl_internal_exceptions.ptr--;
     if (_scl_internal_exceptions.ptr < 0) {
       _scl_unreachable("Impossible state encountered trying to throw an exception!");
@@ -57,13 +57,13 @@ function throw(ex: Exception): none
     _scl_internal_exceptions.extable[_scl_internal_exceptions.ptr] = *ex;
     _scl_internal_callstack.ptr = _scl_internal_exceptions.callstk_ptr[_scl_internal_exceptions.ptr];
     longjmp(_scl_internal_exceptions.jmptable[_scl_internal_exceptions.ptr], 666);
-  end_inline
+  end
 end
 
 function sysPrettyString(): str
   40 malloc => decl sPtr: [int8]
-  inline_c
+  c!
     snprintf((*sPtr), 40, "%s %s", SCL_OS_NAME, SCL_SYSTEM);
-  end_inline
+  end
   sPtr str::new return
 end

--- a/Scale/Frameworks/Scale.framework/include/Scale/io.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/io.scale
@@ -20,21 +20,21 @@ function puts(_str_: str): none
 end
 
 function eputs(_str_: str): none
-  inline_c
+  c!
     fprintf(stderr, "%s\n", (*_str_)->_data);
-  end_inline
+  end
 end
 
 function putint(_int_: int): none
-  inline_c
+  c!
     printf(SCL_INT_FMT "\n", *_int_);
-  end_inline
+  end
 end
 
 function putfloat(_f_: float): none
-  inline_c
+  c!
     printf("%f\n", *_f_);
-  end_inline
+  end
 end
 
 function throwerr(_err_: str): none

--- a/Scale/Frameworks/Scale.framework/include/Scale/math.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/math.scale
@@ -7,9 +7,9 @@ function __init__math_scale(): none
   2.71828182845904523536028747135266250 => MathConstants.e
   3.14159265358979323846264338327950288 => MathConstants.pi
 
-  inline_c
+  c!
     srand(time(NULL));
-  end_inline
+  end
 end
 
 expect function sqrt(_f_: float): float
@@ -32,9 +32,9 @@ expect function log10(_f_: float): float
 
 function random(): int
   decl r: int
-  inline_c
+  c!
     *r = ((scl_int) rand() << 32) | (scl_int) rand();
-  end_inline
+  end
   r return
 end
 

--- a/Scale/Frameworks/Scale.framework/include/Scale/sclobject.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/sclobject.scale
@@ -7,11 +7,11 @@ struct SclObject is ICloneable, IStringifyable, IEquatable, IHashable
     function toString(): str
         decl typenamePtr: [int8]
         decl addressPtr: [int8]
-        inline_c
+        c!
             *typenamePtr = (*self)->$__type_name__;
             *addressPtr = _scl_alloc(21);
             snprintf(*addressPtr, 20, "<%p>", *self);
-        end_inline
+        end
 
         typenamePtr str::new => decl typename: str
         addressPtr str::new => decl address: str
@@ -29,19 +29,19 @@ struct SclObject is ICloneable, IStringifyable, IEquatable, IHashable
 
     function clone() instance: SclObject
         decl sz: mut int
-        inline_c
+        c!
             *sz = (*self)->$__size__;
             *instance = _scl_alloc(*sz);
             _scl_add_struct(*instance);
-        end_inline
+        end
         instance self sz memcpy
         return
     end
 
     function hashCode() hash: int
-        inline_c
+        c!
             *hash = (*self)->$__type__;
-        end_inline
+        end
         return
     end
 

--- a/Scale/Frameworks/Scale.framework/include/Scale/types.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/types.scale
@@ -68,7 +68,7 @@ sealed struct str is IEquatable, ICloneable, IStringifyable
 
   function reverse(): str
     decl out: [int8]
-    inline_c
+    c!
       scl_int i = 0;
       scl_int len = strlen((*self)->_data);
       *out = _scl_alloc(len + 1);
@@ -76,7 +76,7 @@ sealed struct str is IEquatable, ICloneable, IStringifyable
         (*out)[i] = (*self)->_data[len - i - 1];
       }
       (*out)[len] = '\0';
-    end_inline
+    end
     out str::new return
   end
 
@@ -110,9 +110,9 @@ sealed struct str is IEquatable, ICloneable, IStringifyable
     len len2 + 1 + malloc => out
 
     out _str1_ __c_strcpy
-    inline_c
+    c!
       strcat(*out, *_str2_);
-    end_inline
+    end
 
     out return
   end

--- a/Scale/Frameworks/Scale.framework/include/Scale/util/thread.scale
+++ b/Scale/Frameworks/Scale.framework/include/Scale/util/thread.scale
@@ -19,18 +19,18 @@ sealed struct Thread
         if tid then
             "Thread started" ThreadException::new throw
         fi
-        inline_c
+        c!
             pthread_create(&(*self)->tid, NULL, (*self)->func, NULL);
-        end_inline
+        end
     end
 
     function join(): none
         if tid! then
             "Thread ended" ThreadException::new throw
         fi
-        inline_c
+        c!
             pthread_join((*self)->tid, NULL);
-        end_inline
+        end
         nil => self.tid
     end
 end

--- a/examples/cdecl.scale
+++ b/examples/cdecl.scale
@@ -2,11 +2,11 @@ function main(): none
     "Hello, world!" => decl foo: str
 
     # this code will be put directly in the c source file
-    inline_c
+    c!
         printf("Hi!\n");
 
         // in inline-c pseudo-variables exist that are pointers to the actual values
         // they have the same name as the scale variable
         printf("Greeting: %s\n", (*foo)->_data);
-    end_inline
+    end
 end

--- a/loc.txt
+++ b/loc.txt
@@ -19,10 +19,10 @@
      110 Compiler/modules/Function.cpp
      113 Compiler/modules/InfoDumper.cpp
      151 Compiler/modules/Parser.cpp
-    1674 Compiler/modules/SyntaxTree.cpp
+    1675 Compiler/modules/SyntaxTree.cpp
      260 Compiler/modules/TokenHandlers.cpp
-     531 Compiler/modules/Tokenizer.cpp
-    4064 Compiler/modules/Transpiler.cpp
+     541 Compiler/modules/Tokenizer.cpp
+    4071 Compiler/modules/Transpiler.cpp
      134 Scale/Frameworks/Scale.framework/include/Scale/core.scale
       69 Scale/Frameworks/Scale.framework/include/Scale/debug.scale
       56 Scale/Frameworks/Scale.framework/include/Scale/file.scale
@@ -76,4 +76,4 @@
       11 examples/while.scale
        9 interop-example/foo.c
       14 interop-example/main.scale
-   13475 total
+   13493 total

--- a/scale.vscodeextension/snippets/snippets.code-snippets
+++ b/scale.vscodeextension/snippets/snippets.code-snippets
@@ -352,9 +352,9 @@
 		"scope": "source.scale",
 		"prefix": "inline c",
 		"body": [
-			"inline_c",
+			"c!",
 			"\t$0",
-			"end_inline",
+			"end",
 		],
 		"description": "Inline C"
 	},

--- a/scale.vscodeextension/syntaxes/scale.syntax.tmlanguage.json
+++ b/scale.vscodeextension/syntaxes/scale.syntax.tmlanguage.json
@@ -3,7 +3,8 @@
 	"name": "scale",
 	"patterns": [
 		{"include": "#comment"},
-		{"include": "#query"},
+		{"include": "#inline_c"},
+		{"include": "#inline_c_old"},
 		{"include": "#keyw_operator"},
 		{"include": "#keyword"},
 		{"include": "#keyw_constant"},
@@ -75,9 +76,21 @@
 			"name": "variable.name",
 			"match": "[A-Za-z_]+([A-Za-z_0-9]+)?"
 		},
-		"query": {
+		"inline_c_old": {
 			"begin": "\\b(inline_c)\\b",
 			"end": "\\b(end_inline)\\b",
+			"beginCaptures": {
+			  "0": { "name": "keyword.control" }
+			},
+			"endCaptures": {
+			  "0": { "name": "keyword.control" }
+			},
+			"name": "meta.embedded.block.c",
+			"patterns": [{"include": "source.c"}]
+		},
+		"inline_c": {
+			"begin": "\\b(c!)",
+			"end": "\\b(end)\\b",
 			"beginCaptures": {
 			  "0": { "name": "keyword.control" }
 			},


### PR DESCRIPTION
The `asm` function attribute can be used to specify the assembly symbol of a function. It behaves exactly the same as `cdecl` except that it does not prepend an `_` on some platforms.

Example:
```
asm "bar"
function foo(): none
    "Foo!" puts
end
```

Function `foo` has the symbol `bar` in the binary